### PR TITLE
Export RCONConnection type and bump version

### DIFF
--- a/nimrcon.nimble
+++ b/nimrcon.nimble
@@ -1,5 +1,5 @@
 # Package
-version = "0.0.1"
+version = "0.1.0"
 author = "Ilya Tretyakov"
 description = "Simple RCON client"
 license = "MIT"

--- a/src/nimrcon.nim
+++ b/src/nimrcon.nim
@@ -42,7 +42,7 @@ const
     ptEXECCMD* = 2
     ptAUTH* = 3
 
-type RCONConnection = object
+type RCONConnection* = object
     host: string
     port: int
     password: string
@@ -108,3 +108,4 @@ proc newRCONConnection*(host: string = "127.0.0.1",
     result.sock.connect(host, Port(port))
     if not result.auth():
         raise newException(AuthError, "Wrong Password")
+

--- a/src/nimrcon.nim
+++ b/src/nimrcon.nim
@@ -108,4 +108,3 @@ proc newRCONConnection*(host: string = "127.0.0.1",
     result.sock.connect(host, Port(port))
     if not result.auth():
         raise newException(AuthError, "Wrong Password")
-


### PR DESCRIPTION
I was having trouble effectively using this module without having access to the underlying `RCONConnection` type to be able to pass around.